### PR TITLE
Support additional YAML parameters in dump

### DIFF
--- a/ansible_vault/api.py
+++ b/ansible_vault/api.py
@@ -61,10 +61,12 @@ class Vault(object):
         """Read vault steam and return python object."""
         return yaml.safe_load(self.load_raw(stream))
 
-    def dump(self, data, stream=None):
+    def dump(self, data, stream=None, **kwargs):
         """Encrypt data and print stdout or write to stream."""
         yaml_text = yaml.dump(
             data,
             default_flow_style=False,
-            allow_unicode=True)
+            allow_unicode=True,
+            **kwargs
+        )
         return self.dump_raw(yaml_text, stream=stream)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -112,3 +112,19 @@ class TestVaultDump(_TestBase):
         dumped = self._makeOne(secret).dump(plaintext)
 
         assert decrypt_text(dumped, secret) == plaintext + '\n...\n'
+
+    def test_dump_additional_parameters(self):
+        plaintext = 'test'
+        secret = 'password'
+
+        default_style_dumped = self._makeOne(secret).dump(plaintext, default_style='"')
+
+        assert decrypt_text(default_style_dumped, secret) == f'"{plaintext}"\n'
+
+        explicit_start_dumped = self._makeOne(secret).dump(plaintext, explicit_start=True)
+
+        assert decrypt_text(explicit_start_dumped, secret) == f'--- {plaintext}\n...\n'
+
+        canonical_dumped = self._makeOne(secret).dump(plaintext, canonical=True)
+
+        assert decrypt_text(canonical_dumped, secret) == f'---\n!!str "{plaintext}"\n'


### PR DESCRIPTION
This change adds support for additional YAML parameters when dumping using the vault to support multiple YAML formats.