### PR TITLE
Fix version comparison logic

### DIFF
--- a/ansible_vault/api.py
+++ b/ansible_vault/api.py
@@ -20,8 +20,7 @@ import ansible
 import yaml
 
 from ._compat import VaultLib, decode_text
-
-_ANSIBLE_VER = float(".".join(ansible.__version__.split(".")[:2]))
+from pkg_resources import parse_version
 
 
 class Vault(object):
@@ -32,7 +31,7 @@ class Vault(object):
         self.vault = VaultLib(self._make_secrets(self.secret))
 
     def _make_secrets(self, secret):
-        if _ANSIBLE_VER < 2.4:
+        if parse_version(ansible.__version__) < parse_version('2.4'):
             return secret
 
         from ansible.constants import DEFAULT_VAULT_ID_MATCH


### PR DESCRIPTION
Recommended fix for Issue https://github.com/tomoh1r/ansible-vault/issues/32

Update version comparison to use `pkg_resources`, using this instead of `packaging.version.parse` for backwards compatibility.

Tested the `pkg_resources.parse_version` and comparison logic in python 2.7.16 and 3.6.5. 

Pulled information from https://stackoverflow.com/questions/11887762/how-do-i-compare-version-numbers-in-python