### PR TITLE
Fix package not being installable on latest version of setuptools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.1.1 (2025/03/24)
+* Update setup.cfg for compatability with latest setuptools version
+
 2.1.0 (2021/02/07)
 
 * Create VaultLibABC aim to create user vault interface.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [aliases]
 release = register clean --all sdist

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def _read(fname):
 
 setup(
     name="ansible-vault",
-    version="2.1.0",
+    version="2.1.1",
     author="Tomohiro NAKAMURA",
     author_email="quickness.net@gmail.com",
     url="https://github.com/tomoh1r/ansible-vault",


### PR DESCRIPTION
## Description
Fixes package not being installable since setuptools >=78 released. https://github.com/pypa/setuptools/issues/4910

This will require another pypi release to be created too, but at the moment the package can NOT be installed since setuptools 78.0.0 was released.

For anyone who needs this working before this is merged and released you should be able to drop in `git+https://github.com/tomoh1r/ansible-vault.git@refs/pull/54/merge` instead of `ansible-vault` for now.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
